### PR TITLE
Support language-markdown package

### DIFF
--- a/snippets/markdown.build.cson
+++ b/snippets/markdown.build.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'AppVeyor branch':
     'prefix': 'svg-appveyor-branch'
     'body': '[![AppVeyor](https://img.shields.io/appveyor/ci/${1:user}/${2:repository}/${3:branch}.svg${4:?style=flat${5:-square}})]($6)'

--- a/snippets/markdown.downloads.cson
+++ b/snippets/markdown.downloads.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'apm':
     'prefix': 'svg-apm-dl'
     'body': '[![apm](https://img.shields.io/apm/dm/${1:package}.svg${2:?style=flat${3:-square}})](${4:https://atom.io/${5:packages}/${1:package}})'

--- a/snippets/markdown.licenses.cson
+++ b/snippets/markdown.licenses.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'Apache License 2.0':
     'prefix': 'svg-apache'
     'body': '[![Apache License](https://img.shields.io/badge/license-Apache%202.0-${1:orange}.svg${2:?style=flat${3:-square}})](http://www.apache.org/licenses/LICENSE-2.0)'

--- a/snippets/markdown.miscellaneous.cson
+++ b/snippets/markdown.miscellaneous.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'apm license':
     'prefix': 'svg-apm-license'
     'body': '[![apm](https://img.shields.io/apm/l/${1:package}.svg${2:?style=flat${3:-square}})](${4:https://atom.io/${5:packages}/${1:package}})'

--- a/snippets/markdown.social.cson
+++ b/snippets/markdown.social.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'GitHub followers':
     'prefix': 'svg-github-followers'
     'body': '[![GitHub](https://img.shields.io/github/followers/${1:user}/${2:repository}.svg${3:?style=flat${4:-square}})](${5:https://github.com/${1:user}/${2:repository}})'

--- a/snippets/markdown.version.cson
+++ b/snippets/markdown.version.cson
@@ -1,4 +1,4 @@
-'.source.gfm':
+'.source.gfm, .text.md':
   'apm':
     'prefix': 'svg-apm-ver'
     'body': '[![apm](https://img.shields.io/apm/v/${1:package}.svg${2:?style=flat${3:-square}})](${4:https://atom.io/${5:packages}/${1:package}})'


### PR DESCRIPTION
[language-markdown](https://atom.io/packages/language-markdown) has in my opinion much better support for markdown than the stock GFM language. This commit just makes it so those snippets will be usable in the grammar that package adds. 
